### PR TITLE
typo "clients play rates" to "clients pay rates"

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -38,7 +38,7 @@
     <% } else throw new Error('project: yellow not implemented') %>
     <p>Project clients hire me to help with specific legal projects or deals. When a project ends, the working relationship ends with it. In legal jargon, project clients have “limited-scope engagements”.</p>
     <p>I’m always happy to hear from former project clients about new opportunities. But I don’t commit to stay available to project clients after the current project.</p>
-    <p>Some project clients pay an hourly rate and expenses. Some project clients play flat rates, for the whole project, per week, or otherwise. Depends on the project.</p>
+    <p>Some project clients pay an hourly rate and expenses. Some project clients pay flat rates, for the whole project, per week, or otherwise. Depends on the project.</p>
     <p>My going rate for new project work is <%= rate %>. I occasionally lower my rate for clients paying out of pocket, as individuals.</p>
     <h2 id="consultation">Consultation Clients</h2>
     <% if (consultation === 'green') { %>


### PR DESCRIPTION
This commit corrects a small misspelling in the section about project clients. The text says "clients p<em>l</em>ay rates" instead of "clients pay rates".